### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python3 main.py"

--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ Made with [discord.py](https://github.com/Rapptz/discord.py "Github link"), one 
 Made by Sonic4999, better known as SonicTBM on the server.
 
 *The image uses a personal picture from Season 5 as the background, with the Faithful (resource pack) command block texture in the middle.*
+
+EXPERIMENTAL: 
+[![Run on Repl.it](https://repl.it/badge/github/Sonic4999/BappoRealmBot)](https://repl.it/github/Sonic4999/BappoRealmBot)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).